### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # No checkout; only extracts the branch name for downstream jobs.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -44,7 +44,7 @@ jobs:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
     permissions:
-      contents: read
+      contents: read # Required for reusable workflow to clone private module and plugin repos.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -18,6 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions: {} # No checkout; only extracts the branch name for downstream jobs.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
@@ -31,6 +32,7 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
+    timeout-minutes: 30
     permissions:
       contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
@@ -43,6 +45,7 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
+    timeout-minutes: 30
     permissions:
       contents: read # Required for reusable workflow to clone private module and plugin repos.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -34,7 +34,7 @@ jobs:
     needs: setup
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: read # Required for reusable workflow to clone private module and plugin repos.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -20,6 +20,7 @@ permissions: {}
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions: {} # No checkout or GitHub API use; only derives the repository name.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
@@ -30,6 +31,7 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
+    timeout-minutes: 30
     permissions:
       contents: write      # Required for reusable workflow to push coverage reports to gh-pages.
       pull-requests: write # Required for reusable workflow to post PR coverage comments.

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # No checkout or GitHub API use; only derives the repository name.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -29,8 +31,8 @@ jobs:
   codecoverage:
     needs: get-repo-name
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for reusable workflow to push coverage reports to gh-pages.
+      pull-requests: write # Required for reusable workflow to post PR coverage comments.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -16,10 +16,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -24,6 +24,7 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read # Required to clone the repo.
     steps:

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -22,8 +22,8 @@ jobs:
   prep-release:
     name: Prepare Release
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for reusable workflow to push the release branch and commits.
+      pull-requests: write # Required for reusable workflow to open/update the release pull request.
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,6 +21,7 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
+    timeout-minutes: 30
     permissions:
       contents: write      # Required for reusable workflow to push the release branch and commits.
       pull-requests: write # Required for reusable workflow to open/update the release pull request.

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -13,6 +13,7 @@ jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions: {} # Webhook uses secrets.WEBHOOK_TOKEN; default GITHUB_TOKEN is unused.
     steps:
 

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # Webhook uses secrets.WEBHOOK_TOKEN; default GITHUB_TOKEN is unused.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 5 (`satis-update.yml`, `newfold-prep-release.yml`, `lint-php.yml`, `codecoverage-main.yml`, `brand-plugin-test-playwright.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `c0e2480` |
| Timeouts commit | `9b22d48` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| lint-php.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: workflow: BEFORE `permissions: contents: read` -> AFTER `permissions: {}` (with the standard default-deny comment block immediately before `jobs:`) -- Workflow must default to no scopes; jobs that need access declare it explicitly. -- [3] |
| 2 | `brand-plugin-test-playwright.yml` :: `setup`: BEFORE `contents: read` -> AFTER `permissions: {}` -- The job does not check out code or call the GitHub API; it only derives the branch name for downstream jobs. -- [3] |
| 3 | `newfold-prep-release.yml` :: `prep-release`: BEFORE `contents: write` / `pull-requests: write` without per-permission comments -> AFTER the same scopes with aligned inline comments -- Satisfies the audit requirement to document why each scope is needed (release branch commits and release PR). -- [3] |
| 4 | `codecoverage-main.yml` :: `codecoverage`: BEFORE `contents: write` / `pull-requests: write` without per-permission comments -> AFTER the same scopes with aligned inline comments -- Documents gh-pages publish and PR comment behavior of the reusable codecoverage workflow. -- [3] |
| 5 | `brand-plugin-test-playwright.yml` :: `bluehost`: BEFORE `contents: read` without an inline comment -> AFTER `contents: read` with an inline comment -- Same scope, clarified for the Playwright module-in-plugin reusable workflow (fetch of this run timed out; scope assumed from pattern in sibling repos). -- [2] |
| 6 | `brand-plugin-test-playwright.yml` :: `bluehost-dev`: BEFORE `contents: read` without an inline comment -> AFTER `contents: read` with an inline comment -- Same rationale as `bluehost`. -- [2] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `30` | Webhook dispatch is quick; this bounds a hung runner if the external dispatch step misbehaves. |
| newfold-prep-release.yml | prep-release | `30` | Release prep may run npm/composer/build steps; 30 minutes is a safe upper bound without altering any pre-existing timeout (none was set). |
| lint-php.yml | phpcs | `30` | PHP/Composer install plus PHPCS on diffs should finish well under this; prevents a stuck cache or install loop. |
| codecoverage-main.yml | get-repo-name | `30` | Trivial job; timeout only guards a broken runner. |
| codecoverage-main.yml | codecoverage | `30` | Matrix tests, Codeception, and gh-pages publish can run longer than lint but are still expected to complete within half an hour in normal conditions. |
| brand-plugin-test-playwright.yml | setup | `30` | Branch extraction only; very low expected runtime. |
| brand-plugin-test-playwright.yml | bluehost | `30` | Playwright against a brand plugin can be heavier than unit tests; 30 minutes caps runaway E2E or install failures. |
| brand-plugin-test-playwright.yml | bluehost-dev | `30` | Same as `bluehost` for the alternate plugin branch. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main` could not be retrieved in this run (HTTP timeout), so `contents: read` on `bluehost` and `bluehost-dev` is based on the typical need to clone private `module-repo`/`plugin-repo` in that reusable workflow—confirm in-repo if extra scopes (for example `pull-requests: read`) ever become necessary. |


